### PR TITLE
Fix CLANG_ANALYZER_OBJC_COLLECTIONS warning

### DIFF
--- a/BDBOAuth1Manager/BDBOAuth1RequestSerializer.m
+++ b/BDBOAuth1Manager/BDBOAuth1RequestSerializer.m
@@ -329,8 +329,9 @@ static NSDictionary *OAuthKeychainDictionaryForService(NSString *service)
     if (self.consumerKey && self.consumerSecret)
     {
         [mutableAuthorizationParameters addEntriesFromDictionary:[self OAuthParameters]];
-        if (self.accessToken)
-            mutableAuthorizationParameters[@"oauth_token"] = self.accessToken.token;
+        NSString *token = self.accessToken.token;
+        if (token)
+            mutableAuthorizationParameters[@"oauth_token"] = token;
     }
 
     [mutableParameters enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {


### PR DESCRIPTION
"Value stored into `NSMutableDictionary` cannot be nil"
