### PR TITLE
Respect HTTPMethodsEncodingParametersInURI when calculating OAuth

### DIFF
--- a/BDBOAuth1Manager/BDBOAuth1RequestSerializer.m
+++ b/BDBOAuth1Manager/BDBOAuth1RequestSerializer.m
@@ -372,7 +372,7 @@ static NSDictionary *OAuthKeychainDictionaryForService(NSString *service)
     // Only use parameters in the request entity body (with a content-type of `application/x-www-form-urlencoded`).
     // See RFC 5849, Section 3.4.1.3.1 http://tools.ietf.org/html/rfc5849#section-3.4
     NSDictionary *authorizationParameters = parameters;
-    if (!([method isEqualToString:@"GET"] || [method isEqualToString:@"HEAD"] || [method isEqualToString:@"DELETE"]))
+    if (![self.HTTPMethodsEncodingParametersInURI containsObject:method.uppercaseString])
         if (![[request valueForHTTPHeaderField:@"Content-Type"] hasPrefix:@"application/x-www-form-urlencoded"])
             authorizationParameters = nil;
 


### PR DESCRIPTION
We had a weird case where we POST binary data to a URL with a query parameter, which we do with:

```
opManager.requestSerializer.HTTPMethodsEncodingParametersInURI = [opManager.requestSerializer.HTTPMethodsEncodingParametersInURI setByAddingObject:@"POST"];
```

`BDBOAuth1RequestSerializer` should respect this like `AFHTTPRequestSerializer` does.
