### PR TITLE
Fix an Xcode 6 warning

### DIFF
--- a/BDBOAuth1Manager/Categories/NSDictionary+BDBOAuth1Manager.h
+++ b/BDBOAuth1Manager/Categories/NSDictionary+BDBOAuth1Manager.h
@@ -27,7 +27,6 @@
 @interface NSDictionary (BDBOAuth1Manager)
 
 + (instancetype)dictionaryFromQueryString:(NSString *)queryString;
-- (id)initWithQueryString:(NSString *)queryString;
 
 - (NSString *)queryStringRepresentation;
 

--- a/BDBOAuth1Manager/Categories/NSDictionary+BDBOAuth1Manager.m
+++ b/BDBOAuth1Manager/Categories/NSDictionary+BDBOAuth1Manager.m
@@ -28,12 +28,6 @@
 @implementation NSDictionary (BDBOAuth1Manager)
 
 + (instancetype)dictionaryFromQueryString:(NSString *)queryString
-{
-    return [[NSDictionary alloc] initWithQueryString:queryString];
-}
-
-- (id)initWithQueryString:(NSString *)queryString
-{
     NSArray *components = [queryString componentsSeparatedByString:@"&"];
     NSMutableDictionary *dictionary = [NSMutableDictionary dictionary];
     for (NSString *component in components)


### PR DESCRIPTION
Building on Xcode 6 results in the following warning for NSDictionary+BDBOAuth1Manager.m:
"Convenience initializer missing a 'self' call to another initializer"

Since the category's init method is only used in the adjacent class method, I collapsed the two methods into one.

(Another approach would be to use Clang #pragma directives to suppress the warning.)
