### PR TITLE
Bumping AFNetworking to 2.5.x & podspec version to 1.4.2

### DIFF
--- a/BDBOAuth1Manager.podspec
+++ b/BDBOAuth1Manager.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name      = 'BDBOAuth1Manager'
-  s.version   = '1.4.1'
+  s.version   = '1.4.2'
   s.license   = 'MIT'
   s.summary   = 'AFNetworking 2.0-compatible replacement for AFOAuth1Client.'
   s.homepage  = 'https://github.com/bdbergeron/BDBOAuth1Manager'
@@ -14,6 +14,6 @@ Pod::Spec.new do |s|
 
   s.source_files = 'BDBOAuth1Manager/Categories/*.{h,m}', 'BDBOAuth1Manager/*.{h,m}'
 
-  s.dependency 'AFNetworking/NSURLConnection', '~> 2.4.0'
-  s.dependency 'AFNetworking/NSURLSession', '~> 2.4.0'
+  s.dependency 'AFNetworking/NSURLConnection', '~> 2.5.0'
+  s.dependency 'AFNetworking/NSURLSession', '~> 2.5.0'
 end

--- a/BDBOAuth1ManagerDemo/Podfile
+++ b/BDBOAuth1ManagerDemo/Podfile
@@ -4,6 +4,6 @@ platform :ios, '7.0'
 
 link_with 'Twitter Demo', 'Flickr Demo'
 
-pod 'AFNetworking/UIKit', '~> 2.4.0'
+pod 'AFNetworking/UIKit', '~> 2.5.0'
 pod 'BBlock/UIKit', '~> 1.2.0'
 pod 'BDBOAuth1Manager', :path => '../'

--- a/BDBOAuth1ManagerDemo/Podfile.lock
+++ b/BDBOAuth1ManagerDemo/Podfile.lock
@@ -1,25 +1,25 @@
 PODS:
-  - AFNetworking/NSURLConnection (2.4.1):
+  - AFNetworking/NSURLConnection (2.5.0):
     - AFNetworking/Reachability
     - AFNetworking/Security
     - AFNetworking/Serialization
-  - AFNetworking/NSURLSession (2.4.1):
+  - AFNetworking/NSURLSession (2.5.0):
     - AFNetworking/Reachability
     - AFNetworking/Security
     - AFNetworking/Serialization
-  - AFNetworking/Reachability (2.4.1)
-  - AFNetworking/Security (2.4.1)
-  - AFNetworking/Serialization (2.4.1)
-  - AFNetworking/UIKit (2.4.1):
+  - AFNetworking/Reachability (2.5.0)
+  - AFNetworking/Security (2.5.0)
+  - AFNetworking/Serialization (2.5.0)
+  - AFNetworking/UIKit (2.5.0):
     - AFNetworking/NSURLConnection
     - AFNetworking/NSURLSession
   - BBlock/UIKit (1.2.0)
   - BDBOAuth1Manager (1.4.1):
-    - AFNetworking/NSURLConnection (~> 2.4.0)
-    - AFNetworking/NSURLSession (~> 2.4.0)
+    - AFNetworking/NSURLConnection (~> 2.5.0)
+    - AFNetworking/NSURLSession (~> 2.5.0)
 
 DEPENDENCIES:
-  - AFNetworking/UIKit (~> 2.4.0)
+  - AFNetworking/UIKit (~> 2.5.0)
   - BBlock/UIKit (~> 1.2.0)
   - BDBOAuth1Manager (from `../`)
 
@@ -28,8 +28,8 @@ EXTERNAL SOURCES:
     :path: ../
 
 SPEC CHECKSUMS:
-  AFNetworking: 0aabc6fae66d6e5d039eeb21c315843c7aae51ab
+  AFNetworking: 0f54cb5d16ce38c1b76948faffb8d5fb705021c7
   BBlock: 90f0ae0e3ba94fc88be6b9a85b4adbb73b8a7c9a
-  BDBOAuth1Manager: 51b0f15c7592e0a97bc0879dda786262dcd6bd9a
+  BDBOAuth1Manager: a0a99ed94472207f473414689652b6ddab2f998e
 
-COCOAPODS: 0.34.1
+COCOAPODS: 0.35.0


### PR DESCRIPTION
Current 1.4.1 release can't be used with AFNetworking 2.5 which was released a couple days ago:

```
Update all pods
Analyzing dependencies
[!] Unable to satisfy the following requirements:

- `AFNetworking/NSURLConnection (= 2.5.0)` required by `AFNetworking (2.5.0)`
- `AFNetworking/NSURLConnection (~> 2.4.0)` required by `BDBOAuth1Manager (1.4.1)`
```
