### PR TITLE
Rename local variables to avoid shadowing those at higher scope

### DIFF
--- a/BDBOAuth1Manager/BDBOAuth1RequestOperationManager.m
+++ b/BDBOAuth1Manager/BDBOAuth1RequestOperationManager.m
@@ -94,10 +94,10 @@
         success(requestToken);
     };
 
-    void (^failureBlock)(AFHTTPRequestOperation *, NSError *) = ^(AFHTTPRequestOperation *operation, NSError *error) {
+    void (^failureBlock)(AFHTTPRequestOperation *, NSError *) = ^(AFHTTPRequestOperation *operation, NSError *completionError) {
         self.responseSerializer = defaultSerializer;
 
-        failure(error);
+        failure(completionError);
     };
 
     AFHTTPRequestOperation *operation = [self HTTPRequestOperationWithRequest:request success:successBlock failure:failureBlock];
@@ -147,11 +147,11 @@
         success(accessToken);
     };
 
-    void (^failureBlock)(AFHTTPRequestOperation *, NSError *) = ^(AFHTTPRequestOperation *operation, NSError *error) {
+    void (^failureBlock)(AFHTTPRequestOperation *, NSError *) = ^(AFHTTPRequestOperation *operation, NSError *completionError) {
         self.responseSerializer = defaultSerializer;
         self.requestSerializer.requestToken = nil;
 
-        failure(error);
+        failure(completionError);
     };
 
     AFHTTPRequestOperation *operation = [self HTTPRequestOperationWithRequest:request success:successBlock failure:failureBlock];

--- a/BDBOAuth1Manager/BDBOAuth1SessionManager.m
+++ b/BDBOAuth1Manager/BDBOAuth1SessionManager.m
@@ -87,11 +87,11 @@
         return;
     }
 
-    void (^completionBlock)(NSURLResponse * __unused, id, NSError *) = ^(NSURLResponse * __unused response, id responseObject, NSError *error) {
+    void (^completionBlock)(NSURLResponse * __unused, id, NSError *) = ^(NSURLResponse * __unused response, id responseObject, NSError *completionError) {
         self.responseSerializer = defaultSerializer;
 
-        if (error) {
-            failure(error);
+        if (completionError) {
+            failure(completionError);
 
             return;
         }
@@ -138,12 +138,12 @@
         return;
     }
 
-    void (^completionBlock)(NSURLResponse * __unused, id, NSError *) = ^(NSURLResponse * __unused response, id responseObject, NSError *error) {
+    void (^completionBlock)(NSURLResponse * __unused, id, NSError *) = ^(NSURLResponse * __unused response, id responseObject, NSError *completionError) {
         self.responseSerializer = defaultSerializer;
         self.requestSerializer.requestToken = nil;
 
-        if (error) {
-            failure(error);
+        if (completionError) {
+            failure(completionError);
 
             return;
         }


### PR DESCRIPTION
In our project that uses BDBOAuth1Manager, I enabled the Xcode "Hidden Local Variables" warning (i.e., `GCC_WARN_SHADOW`), and these lines got flagged.