### PR TITLE
allow sending of a generic OAuth signed request

### DIFF
--- a/BDBOAuth1Manager/BDBOAuth1SessionManager.h
+++ b/BDBOAuth1Manager/BDBOAuth1SessionManager.h
@@ -115,6 +115,23 @@
                          success:(void (^)(BDBOAuth1Credential *accessToken))success
                          failure:(void (^)(NSError *error))failure;
 
+
+/**
+ *  Sends a generic OAuth signed request (using "Authentication" header) for JSON object.
+ *  You should have successfully fetched access token first before using this method.
+ *
+ *  @param accessPath   An endpoint that requires an OAuth signed request.
+ *  @param method       HTTP method for the request.
+ *  @param parameters   The parameters to be either set as a query string for `GET` requests, or the request HTTP body.
+ *  @param success      Completion block performed upon successful request.
+ *  @param failure      Completion block performed if the request failed.
+ */
+- (void)jsonObjectWithPath:(NSString *)accessPath
+                    method:(NSString *)method
+                parameters:(NSDictionary *)parameters
+                   success:(void (^)(NSURLResponse *response, id jsonObject))success
+                   failure:(void (^)(NSURLResponse *response, NSError *error))failure;
+
 @end
 
 #endif

--- a/BDBOAuth1Manager/BDBOAuth1SessionManager.m
+++ b/BDBOAuth1Manager/BDBOAuth1SessionManager.m
@@ -160,6 +160,38 @@
     [task resume];
 }
 
+- (void)jsonObjectWithPath:(NSString *)accessPath
+                    method:(NSString *)method
+                parameters:(NSDictionary *)parameters
+                   success:(void (^)(NSURLResponse *response, id jsonObject))success
+                   failure:(void (^)(NSURLResponse *response, NSError *error))failure {
+    
+    AFHTTPResponseSerializer *defaultSerializer = self.responseSerializer; // save old serializer for restore after request is completed
+    self.responseSerializer = [AFJSONResponseSerializer serializer]; // override serializer
+    
+    NSString *URLString = [[NSURL URLWithString:accessPath relativeToURL:self.baseURL] absoluteString];
+    NSError *error;
+    NSMutableURLRequest *request = [self.requestSerializer requestWithMethod:method URLString:URLString parameters:parameters error:&error];
+    
+    if (error) {
+        failure(nil, error);
+        return;
+    }
+    
+    void (^completionBlock)(NSURLResponse * __unused, id, NSError *) = ^(NSURLResponse * __unused response, id responseObject, NSError *completionError) {
+        self.responseSerializer = defaultSerializer; // restore the old serializer
+        
+        if (completionError) {
+            failure(response, completionError);
+            return;
+        }
+        success(response, responseObject);
+    };
+    
+    NSURLSessionDataTask *task = [self dataTaskWithRequest:request completionHandler:completionBlock];
+    [task resume];
+}
+
 @end
 
 #endif


### PR DESCRIPTION
I was working with Fitbit API using your lib. I can request request_token and access_token no problem. But after that, it's missing the ability to send generic OAuth signed requests to fetch other JSON data after I have acquired the permanent access token. So I added it. :)

I tested this method in my personal project so it should work correctly. I’m not sure how to write test for this method or ensure its functionality in someway in your project though.